### PR TITLE
Admin menu bar: move 'Users' above 'Organizations' #629

### DIFF
--- a/app/admin/organizations.rb
+++ b/app/admin/organizations.rb
@@ -1,11 +1,7 @@
 ActiveAdmin.register Organization do
-  menu priority: 2
+  menu parent: "Users"
   actions :all, except: [:show]
-
-  permit_params do
-    permitted = [:title]
-    permitted
-  end
+ 
 
   breadcrumb do
     links = [link_to('Admin', admin_root_path), link_to('Organizations', admin_organizations_path)]

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,6 +1,12 @@
 ActiveAdmin.register User do
-  menu parent: "Organizations"
+  menu priority: 2
   actions :all, except: [:show]
+
+  permit_params do
+    permitted = [:title]
+    permitted
+  end
+ 
 
   breadcrumb do
     links = [link_to('Admin', admin_root_path), link_to('Users', admin_users_path)]


### PR DESCRIPTION
Here's the fix for admin menu bar list item re-ordering.  Please test.