### PR TITLE
Admin/New User password input type changed from password to text.

### DIFF
--- a/vendor/assets/javascripts/active_admin.js
+++ b/vendor/assets/javascripts/active_admin.js
@@ -1695,7 +1695,7 @@ jQuery(function($) {
           <ol>
             <li class="string input optional stringish">
               <label class="label">Password</label>
-              <input id="__password" :maxlength="range" type="password" v-model="password">
+              <input id="__password" :maxlength="range" type="text" v-model="password">
               <div v-if="editPass" class="text-danger ml-20 p-5">
                 <div v-if="C_passValidationCheck.length" class="font-sm text-danger">Password must contains {{range}} characters.</div>
                 <div v-if="C_passValidationCheck.uppercase" class="font-sm text-danger">Contain at least 1 uppercase letter.</div>


### PR DESCRIPTION
Please test.

Changed HTML input type="password" to "text". This type change also enabled the “Copy Password” function and now renders viewable (alphanumeric) characters.

This fix may require the password generator to also output special characters in accordance with the password validation guidelines. Working that issue now.