### PR TITLE
#892:  Dates in exports changed to formats on datepickers, eg, 12 Nov 2020

### DIFF
--- a/app/javascript/components/dashboard/issues/issue_index.vue
+++ b/app/javascript/components/dashboard/issues/issue_index.vue
@@ -147,8 +147,8 @@
             <td>{{issue.title}}</td>
             <td>{{issue.issueType}}
             <td>{{issue.issueSeverity}}
-            <td>{{issue.startDate}}</td>
-            <td>{{issue.dueDate}}</td>
+            <td>{{formatDate(issue.startDate)}}</td>
+            <td>{{formatDate(issue.dueDate)}}</td>
             <td>{{issue.users.join(', ')}}</td>
             <td>{{issue.progress + "%"}}</td>
             <td v-if="(issue.notes.length) > 0">{{issue.notes[0].body}}</td>

--- a/app/javascript/components/dashboard/issues/issue_sheets_index.vue
+++ b/app/javascript/components/dashboard/issues/issue_sheets_index.vue
@@ -155,8 +155,8 @@
                 <td>{{issue.title}}</td>
                 <td>{{issue.issueType}}
                 <td>{{issue.issueSeverity}}
-                <td>{{issue.startDate}}</td>
-                <td>{{issue.dueDate}}</td>
+                <td>{{formatDate(issue.startDate)}}</td>
+                <td>{{formatDate(issue.dueDate)}}</td>
                 <td>{{issue.users.join(', ')}}</td>
                 <td>{{issue.progress + "%"}}</td>
                 <td v-if="(issue.notes.length) > 0">{{issue.notes[0].body}}</td>

--- a/app/javascript/components/dashboard/tasks/task_index.vue
+++ b/app/javascript/components/dashboard/tasks/task_index.vue
@@ -105,8 +105,8 @@
           <td class="text-center">{{i+1}}</td>
           <td>{{task.text}}</td>
           <td>{{task.taskType}}
-          <td>{{task.startDate}}</td>
-          <td>{{task.dueDate}}</td>
+          <td>{{formatDate(task.startDate)}}</td>
+          <td>{{formatDate(task.dueDate)}}</td>
           <td>{{task.users.join(', ')}}</td>
           <td>{{task.progress + "%"}}</td>
           <td v-if="(task.notes.length) > 0">{{task.notes[0].body}}</td>

--- a/app/javascript/components/dashboard/tasks/task_sheets_index.vue
+++ b/app/javascript/components/dashboard/tasks/task_sheets_index.vue
@@ -95,8 +95,8 @@
               <td class="text-center">{{i+1}}</td>
               <td>{{task.text}}</td>
               <td>{{task.taskType}}
-              <td>{{task.startDate}}</td>
-              <td>{{task.dueDate}}</td>
+              <td>{{formatDate(task.startDate)}}</td>
+              <td>{{formatDate(task.dueDate)}}</td>
               <td>{{task.users.join(', ')}}</td>
               <td>{{task.progress + "%"}}</td>
               <td v-if="(task.notes.length) > 0">{{task.notes[0].body}}</td>


### PR DESCRIPTION
Result:
![image](https://user-images.githubusercontent.com/72885316/98941869-24cf9400-24bb-11eb-8869-3a3f3767a3f5.png)
